### PR TITLE
chore: Remove exported true in android manifest file.

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -8,8 +8,7 @@
       android:icon="@mipmap/ic_launcher"
       android:roundIcon="@mipmap/ic_launcher_round"
       android:allowBackup="false"
-      android:theme="@style/AppTheme"
-      android:exported="true">
+      android:theme="@style/AppTheme">
 
         <activity
             android:name=".SplashActivity"


### PR DESCRIPTION
# Remove exported true in android manifest file
## Description
- remove `exported: true` in android manifest application.